### PR TITLE
Update map.js checks to confirm geometry data issuing supplied

### DIFF
--- a/service/static/javascripts/map.js
+++ b/service/static/javascripts/map.js
@@ -7,7 +7,7 @@ window.onload = function() {
   if (indexData &&
       (
         (indexData.geometry && indexData.geometry.coordinates && indexData.geometry.coordinates.length > 0) ||
-        (indexData.features[0].geometry && indexData.features[0].geometry.coordinates && indexData.features[0].geometry.coordinates.length > 0)
+        (indexData.features && indexData.features[0].geometry && indexData.features[0].geometry.coordinates && indexData.features[0].geometry.coordinates.length > 0)
       )
     ) {
 


### PR DESCRIPTION
While updating the feeder I noticed a gap in the check to confirm geometry data has been provided.
In the case where indexData is an empty object the the check would try to access an object that didn't exist.
