### PR TITLE
Updated flow and No results found screen

### DIFF
--- a/service/server.py
+++ b/service/server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from service import app
 import os
-from flask import Flask, abort, render_template, request, redirect, flash, url_for, session
+from flask import Flask, abort, render_template, request, redirect, url_for, session
 import requests
 import re
 import logging
@@ -30,7 +30,7 @@ def display_title(title_ref):
 
 @app.route('/title-search/', methods=['GET', 'POST'])
 def find_titles():
-    if request.method == "POST" and request.form['search_term']:
+    if request.method == "POST":
         search_term = request.form['search_term']
         logger.info("SEARCH REGISTER: {0} was searched by {1}".format(search_term, "todo-user"))
         # Determine search term type and preform search
@@ -46,9 +46,8 @@ def find_titles():
                 # If title not found display 'no title found' screen
                 return render_template('no_title_number_results.html', asset_path = '../static/', search_term=search_term)
         else:
-            # If the search value was not in an expected format, return to search screen with error message
-            flash('Search value not in a recognised format')
-            return render_template('search.html', asset_path = '../static/', search_term=search_term)
+            # If search value doesn't match, return no results found screen
+            return render_template('no_title_number_results.html', asset_path = '../static/', search_term=search_term)
     else:
         # If not search value enter or a GET request, display the search page
         return render_template('search.html', asset_path = '../static/')

--- a/service/templates/no_title_number_results.html
+++ b/service/templates/no_title_number_results.html
@@ -13,24 +13,25 @@
                     <li>Results</li>
                 </ol>
             </div>
-
+            <p/>
             <div class="outer-block">
                 <div class="inner-block">
 
                     <div class="text">
 
-                        <h1 class="heading-xlarge">
-                            No Results
-                        </h1>
+                      <form action="/title-search/" method="POST" role="form">
+                          <div class="form-group">
+                              <label class="form-label-bold" for="search-terms">
+                                  Search results for:
+                              </label>
+                              <input type="text" class="form-control" name="search_term" id="search_term" value="{% if search_term %}{{ search_term }}{% endif %}"/>
+                              <button type="submit" class="button">Search</button>
+                          </div>
+                      </form>
 
-                        <p class="lede">No result(s) found for the Title Number: <strong>{{ search_term }}</strong></p>
+                        <p class="lede">No result(s) found</p>
 
                     </div>
-                    <form action="/title-search/" method="GET" role="form">
-                        <div class="form-group">
-                            <button type="submit" class="button">New Search</button>
-                        </div>
-                    </form>
 
                 </div>
             </div>

--- a/service/templates/no_title_number_results.html
+++ b/service/templates/no_title_number_results.html
@@ -13,7 +13,7 @@
                     <li>Results</li>
                 </ol>
             </div>
-            <p/>
+
             <div class="outer-block">
                 <div class="inner-block">
 
@@ -21,8 +21,10 @@
 
                       <form action="/title-search/" method="POST" role="form">
                           <div class="form-group">
-                              <label class="form-label-bold" for="search-terms">
-                                  Search results for:
+                              <label for="search-terms">
+                                  <h1 class="heading-medium">
+                                      Search results for: <span class="visuallyhidden">{% if search_term %}{{ search_term }}{% endif %}</span>
+                                  </h1>
                               </label>
                               <input type="text" class="form-control" name="search_term" id="search_term" value="{% if search_term %}{{ search_term }}{% endif %}"/>
                               <button type="submit" class="button">Search</button>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -94,9 +94,9 @@ class ViewTitleTestCase(unittest.TestCase):
 
     def test_title_search_invalid_search_value_format(self):
         response = self.app.post('/title-search/', data=dict(search_term='invalid value'))
-        self.assertIn('Search value not in a recognised format', str(response.data))
+        self.assertIn('No result(s) found', str(response.data))
 
     @mock.patch('requests.get', return_value=unavailable_title)
     def test_title_search_title_not_found(self, mock_get):
         response = self.app.post('/title-search/', data=dict(search_term='DT1000'))
-        self.assertIn('No result(s) found for the Title Number: ', str(response.data))
+        self.assertIn('No result(s) found', str(response.data))


### PR DESCRIPTION
Have updated the no results found screen to have a search box on (as per prototype screens for multiple results page). No longer display an validation/error message if the search value doesn't meet the expected format for a title number, just go to the no results found screen (without doing a search).
Removed the 'New Search' button as searching can now be done from this screen. Navigation can be done via the breadcrumbs at the top.
