### PR TITLE
Fixed HTML validation failures by providing an Action for the form

### DIFF
--- a/service/templates/display_login.html
+++ b/service/templates/display_login.html
@@ -10,7 +10,7 @@
 
             <h1 class="heading-large">Digital Register Login</h1>
 
-            <form action="" method="post" class="form">
+            <form action="login" method="post" class="form">
                 {{ form.hidden_tag() }}
                 <div class="form-group">
                     <label for="username" class="form-label">Username</label>


### PR DESCRIPTION
Gave the form a non-empty Action so HTML Validation doesn't complain.
