### PR TITLE
Set session cookie protection mode to strong

### DIFF
--- a/service/__init__.py
+++ b/service/__init__.py
@@ -15,6 +15,7 @@ app.config.update(CONFIG_DICT)
 login_manager = LoginManager()
 login_manager.init_app(app)
 login_manager.login_view = '/login'
+login_manager.session_protection = "strong"
 
 
 def format_datetime(value):


### PR DESCRIPTION
Done as a part of US100 (https://www.pivotaltracker.com/n/projects/1250320/stories/91603980). The default protection mode is `basic`, which also requires the user to reauthenticate if the cookie is stolen. In `strong` mode the whole session is deleted in such case.
