### PR TITLE
Rename and reorganize template blocks

### DIFF
--- a/service/templates/imports.html
+++ b/service/templates/imports.html
@@ -1,13 +1,8 @@
 {% extends "layout.html" %}
 
-{% block head %}
+{% block head_additionals %}
   <link rel="stylesheet" href="{{asset_path}}vendor/leaflet-0.7.3/leaflet.css" />
-  {% block head_additionals %}{% endblock %}
-{% endblock %}
-
-{% block body_end %}
   <script src="{{asset_path}}vendor/leaflet-0.7.3/leaflet.js"></script><!-- Leaflet -->
   <script src="{{asset_path}}javascripts/proj4.js"></script><!-- proj4js -->
   <script src="{{asset_path}}javascripts/proj4leaflet.js"></script><!-- proj4leaflet -->
-  {% block js_additionals %}{% endblock %}
 {% endblock %}

--- a/service/templates/layout.html
+++ b/service/templates/layout.html
@@ -8,6 +8,8 @@
 </script>
 <script src="{{ asset_path }}javascripts/googleanalytics.js"></script>
 
+{% block head_additionals %}{% endblock %}
+{% block js_additionals %}{% endblock %}
 {% endblock %}
 
 {% block cookie_message %}


### PR DESCRIPTION
Rename and reorganize the template blocks so they don't overwrite each other because of having the
same names.
