### PR TITLE
Breadcrumb role no longer exists in W3C for ol

### DIFF
--- a/service/templates/search_results.html
+++ b/service/templates/search_results.html
@@ -7,7 +7,7 @@
             {% include "beta_banner.html" %}
 
             <div id="global-breadcrumb">
-                <ol role="breadcrumbs">
+                <ol>
                     <li><a href="/">Home</a></li>
                     <li><a href="/title-search/">Search for Title</a></li>
                     <li>Results</li>


### PR DESCRIPTION
http://www.w3.org/TR/wai-aria/roles#landmark_roles
