### PR TITLE
Update register title page to show tenure info

### DIFF
--- a/service/templates/display_title.html
+++ b/service/templates/display_title.html
@@ -42,6 +42,11 @@
                           <p>{{ proprietor.name }}</p>
                         {% endfor %}
                         </dd>
+
+                        <dt>Tenure</dt>
+                        <dd>
+                            <p>{{ title.tenure }}</p>
+                        </dd>
                     </dl>
 
                 </div><!-- /summary -->

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -110,6 +110,11 @@ class TestViewTitle:
         assert 'Scott Oakes' in response.data.decode()
 
     @mock.patch('requests.get', return_value=fake_title)
+    def test_tenure_on_title_page(self, mock_get):
+        response = self.app.get('/titles/titleref')
+        assert 'Freehold' in response.data.decode()
+
+    @mock.patch('requests.get', return_value=fake_title)
     def test_index_geometry_on_title_page(self, mock_get):
         coordinate_data = '[[[508263.97, 221692.13],'
         response = self.app.get('/titles/titleref')


### PR DESCRIPTION
The register title page now shows the tenure in the summary box and underneath in the 'Property Details' section
