### PR TITLE
US119 - set PYTHONPATH environment variable to application root directory

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -6,3 +6,4 @@ export GOOGLE_ANALYTICS_API_KEY='UA-59849906-2'
 export APPLICATION_SECRET_KEY='secretkeyshouldberandom'
 export LOGIN_API='http://landregistry.local:8005/'
 export SESSION_COOKIE_SECURE='False'
+export PYTHONPATH=.


### PR DESCRIPTION
This is needed to make sure gunicorn will locate settings file by relative path.
