### PR TITLE
US119 - Store application fault details in separate log file

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,12 +7,14 @@ logging_config_file_path = os.environ['LOGGING_CONFIG_FILE_PATH']
 google_analytics_api_key = os.environ['GOOGLE_ANALYTICS_API_KEY']
 secret_key = os.environ['APPLICATION_SECRET_KEY']
 session_cookie_secure = os.environ['SESSION_COOKIE_SECURE'].lower() != 'false'
+fault_log_file_path = os.environ['FAULT_LOG_FILE_PATH']
 
 CONFIG_DICT = {
     'DEBUG': False,
     'LOGGING': True,
     'REGISTER_TITLE_API': register_title_api,
     'LOGGING_CONFIG_FILE_PATH': logging_config_file_path,
+    'FAULT_LOG_FILE_PATH': fault_log_file_path,
     'GOOGLE_ANALYTICS_API_KEY': google_analytics_api_key,
     'LOGIN_API': login_api,
     'PERMANENT_SESSION_LIFETIME': datetime.timedelta(minutes=15),
@@ -32,3 +34,4 @@ elif settings == 'test':
     CONFIG_DICT['DEBUG'] = True
     CONFIG_DICT['SLEEP_BETWEEN_LOGINS'] = False
     CONFIG_DICT['DISABLE_CSRF_PREVENTION'] = True
+    CONFIG_DICT['FAULT_LOG_FILE_PATH'] = '/dev/null'

--- a/environment.sh
+++ b/environment.sh
@@ -2,6 +2,7 @@
 export SETTINGS='dev'
 export REGISTER_TITLE_API='http://landregistry.local:8004/'
 export LOGGING_CONFIG_FILE_PATH='logging_config.json'
+export FAULT_LOG_FILE_PATH='/var/log/applications/digital-register-frontend-fault.log'
 export GOOGLE_ANALYTICS_API_KEY='UA-59849906-2'
 export APPLICATION_SECRET_KEY='secretkeyshouldberandom'
 export LOGIN_API='http://landregistry.local:8005/'

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -7,8 +7,9 @@ from flask_login import LoginManager
 from config import CONFIG_DICT
 from service import logging_config
 
-# This causes the traceback to be written to stderr in case of faults
-faulthandler.enable()
+# This causes the traceback to be written to the fault log file in case of serious faults
+fault_log_file = open(CONFIG_DICT['FAULT_LOG_FILE_PATH'], 'a')
+faulthandler.enable(file=fault_log_file)
 
 app = Flask(__name__)
 app.config.update(CONFIG_DICT)


### PR DESCRIPTION
When application crashes or gets killed by a signal, it should output the fault details into a file. We can't log it in a standard way. We can only tell faulthandler where to write.
