### PR TITLE
Minor bug fixes and design change for detailed proprietor name

### DIFF
--- a/service/server.py
+++ b/service/server.py
@@ -257,29 +257,32 @@ def format_proprietors(proprietors_data):
     for proprietor in proprietors_data:
         name = proprietor.get('name') or ''
         addresses = proprietor.get('addresses') or []
-        formatted_proprietor = {}
-        if 'name_information' in name:
-            formatted_proprietor["name_information"] = ', ' + name['name_information']
+        formatted_proprietor = {"name_extra_info": ""}
+        if 'forename' in name or 'surname' in name:
+            formatted_proprietor["name"] = format_pi_name(name)
         if 'name_supplimentary' in name:
-            formatted_proprietor["name_supplimentary"] = ', ' + name['name_supplimentary']
+            formatted_proprietor["name_extra_info"] += ', ' + name['name_supplimentary']
+        if 'name_information' in name:
+            formatted_proprietor["name_extra_info"] += ', ' + name['name_information']
         if 'charity_name' in name:
             charity_name = ' of '
             if name['charity_name'].endswith(")"):
-                charity_name += '('
+                charity_name = ' ('
+            else:
+                charity_name = ' of '
             charity_name += name['charity_name']
-            formatted_proprietor["charity_name"] = charity_name
+            formatted_proprietor["name_extra_info"] += charity_name
         if 'trading_name' in name:
-            formatted_proprietor["trading_name"] = ' trading as ' + name['trading_name']
-        if 'forename' in name or 'surname' in name:
-            formatted_proprietor["name"] = format_pi_name(name)
+            formatted_proprietor["name_extra_info"] += ' trading as ' + name['trading_name']
         if 'non_private_individual_name' in name:
             formatted_proprietor["name"] = name['non_private_individual_name']
             if 'company_reg_num' in name:
                 formatted_proprietor["co_reg_no"] = 'Company registration number '\
                                                     + name['company_reg_num']
             if 'country_incorporation' in name:
-                formatted_proprietor["country_incorporation"] = 'incorporated in '\
+                formatted_proprietor["name_extra_info"] += ' incorporated in '\
                                                                 + name['country_incorporation']
+
         formatted_proprietor["addresses"] = []
         for address in addresses:
             formatted_proprietor["addresses"] += [{

--- a/service/server.py
+++ b/service/server.py
@@ -282,6 +282,14 @@ def format_proprietors(proprietors_data):
             if 'country_incorporation' in name:
                 formatted_proprietor["name_extra_info"] += ' incorporated in '\
                                                                 + name['country_incorporation']
+            if 'company_location' in name:
+                if name['company_location'] == 'SC':
+                    formatted_location = 'in Scotland'
+                elif name['company_location'] == 'NI':
+                    formatted_location = 'in Northern Ireland'
+                else:
+                    formatted_location = 'overseas'
+                formatted_proprietor["company_location"] = 'Registered '+formatted_location
 
         formatted_proprietor["addresses"] = []
         for address in addresses:

--- a/service/static/stylesheets/landregistry/lr-register.scss
+++ b/service/static/stylesheets/landregistry/lr-register.scss
@@ -6,3 +6,7 @@
 #map {
   margin-bottom: $gutter*2;
 }
+
+.address {
+  padding: 0 15px;
+}

--- a/service/static/stylesheets/landregistry/lr-register.scss
+++ b/service/static/stylesheets/landregistry/lr-register.scss
@@ -10,3 +10,8 @@
 .address {
   padding: 0 15px;
 }
+
+.sub-address {
+  font-size: 16px;
+  padding: 0 15px;
+}

--- a/service/templates/display_title.html
+++ b/service/templates/display_title.html
@@ -35,6 +35,11 @@
               <div class="address">
                 {{ proprietor.co_reg_no }}
               </div>
+              {% if proprietor.company_location %}
+                <div class="sub-address">
+                  {{ proprietor.company_location }}
+                </div>
+              {% endif %}
             </div>
           {% endif %}
           {% for address in proprietor.addresses %}
@@ -58,6 +63,13 @@
                 <div class="grid-row expand-bottom-half">
                   <div class="address">
                     {{ lender.co_reg_no }}
+                  </div>
+                </div>
+              {% endif %}
+              {% if lender.company_location %}
+                <div class="grid-row expand-bottom-half">
+                  <div class="sub-address">
+                    {{ lender.company_location }}
                   </div>
                 </div>
               {% endif %}

--- a/service/templates/display_title.html
+++ b/service/templates/display_title.html
@@ -27,11 +27,19 @@
       <dt>Owner{{ title.proprietors|length|pluralize }}</dt>
       <dd>
         {% for proprietor in title.proprietors %}
-          <h5 class="heading-small collapse-top expand-bottom-half">{{ proprietor.name }}{{ proprietor.name_supplimentary }}{{ proprietor.name_information }}{{ proprietor.charity_name }}{{ proprietor.trading_name }}{{ proprietor.country_incorporation }}</h5>
-          {{ proprietor.co_reg_no }}
+          <h5 class="collapse-top expand-bottom-half">
+            <span class="heading-small">{{ proprietor.name }}</span>{{ proprietor.name_extra_info }}
+          </h5>
+          {% if proprietor.co_reg_no %}
+            <div class="grid-row expand-bottom-half">
+              <div class="address">
+                {{ proprietor.co_reg_no }}
+              </div>
+            </div>
+          {% endif %}
           {% for address in proprietor.addresses %}
             <div class="grid-row expand-bottom-half">
-              <div class="column-half">
+              <div class="address">
                 {{ '<br>'.join(address.lines)|safe }}
               </div>
             </div>
@@ -43,12 +51,19 @@
         <dt>Lender{{ title.lenders|length|pluralize }}</dt>
         <dd>
           {% for lender in title.lenders %}
-              <h5 class="heading-small collapse-top expand-bottom-half">
-                {{ lender.name }}
+              <h5 class="collapse-top expand-bottom-half">
+                <span class="heading-small">{{ lender.name }}</span>{{ lender.name_extra_info }}
               </h5>
+              {% if lender.co_reg_no %}
+                <div class="grid-row expand-bottom-half">
+                  <div class="address">
+                    {{ lender.co_reg_no }}
+                  </div>
+                </div>
+              {% endif %}
               {% for address in lender.addresses %}
                 <div class="grid-row expand-bottom-half">
-                  <div class="column-half">
+                  <div class="address">
                     {{ '<br>'.join(address.lines)|safe }}
                   </div>
                 </div>

--- a/tests/data/fake_title.json
+++ b/tests/data/fake_title.json
@@ -45,6 +45,23 @@
                       "title": "Lady",
                       "charity_name": "looking after dogs for life charity)"
                   }
+              },
+              {
+                  "addresses": [
+                      {
+                          "address_string": "11 Fore Street, Plymouth PL8 6TG",
+                          "address_type": "UNKNOWN",
+                          "auto_uppercase_override": true
+                      }
+                  ],
+                  "name": {
+                      "name_category": "LIMITED COMPANY OR PUBLIC LIMITED COMPANY",
+                      "auto_uppercase_override": true,
+                      "non_private_individual_name": "Babel Fish",
+                      "company_reg_num": "999888999",
+                      "company_location": "OV",
+                      "country_incorporation": "Narnia"
+                  }
               }
           ],
           "last_application_timestamp": "2014-08-28T12:37:13+01:00",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -178,6 +178,8 @@ class TestViewTitle(BaseServerTest):
         assert 'trading as RKJ Machinists PLC' in page_content
         assert 'Dr' in page_content
         assert '(looking after dogs for life charity)' in page_content
+        assert 'Registered overseas' in page_content
+        assert 'Company registration number 999888999' in page_content
 
 
 class TestTitleSearch(BaseServerTest):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -177,7 +177,7 @@ class TestViewTitle(BaseServerTest):
         page_content = response.data.decode()
         assert 'trading as RKJ Machinists PLC' in page_content
         assert 'Dr' in page_content
-        assert 'of (looking after dogs for life charity)' in page_content
+        assert '(looking after dogs for life charity)' in page_content
 
 
 class TestTitleSearch(BaseServerTest):


### PR DESCRIPTION
## What it looks like now

![screen shot 2015-06-17 at 13 30 11](https://cloud.githubusercontent.com/assets/5455804/8206869/05103d62-14f5-11e5-9d64-bb4afba091dd.png)
## Noteworthy fixes
- addresses are wider so no longer "squashed up" over several lines when viewing in full page
- no more space missing before "incorporated"
- no more `of (` with the charity name when it has parentheses

Before:
![screen shot 2015-06-17 at 13 20 41](https://cloud.githubusercontent.com/assets/5455804/8206885/281f55fe-14f5-11e5-982d-b77b42a415c1.png)
After:
![screen shot 2015-06-17 at 13 21 34](https://cloud.githubusercontent.com/assets/5455804/8206892/33d9dd10-14f5-11e5-9e3d-e64b7b2d4eed.png)
- separate line for company_reg_num
- lenders benefit from detailed name view too! :boom:
