### PR TITLE
US135 add breadcrumbs to title display page

### DIFF
--- a/service/templates/search_results.html
+++ b/service/templates/search_results.html
@@ -22,7 +22,7 @@
       {% for title in results['titles'] %}
         <li>
           <h2 class="heading-small collapse-bottom">
-            <a href="{{ url_for('display_title', title_ref=title['title_number']) }}">{{ title['data']['address']['address_string'] }}</a>
+            <a href="{{ url_for('display_title', title_ref=title['title_number'], page_number=results['page_number'], search_term=search_term) }}">{{ title['data']['address']['address_string'] }}</a>
           </h2>
           <div class="font-xsmall">
             Title number {{ title['title_number'] }}<br>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -172,6 +172,23 @@ class TestViewTitle(BaseServerTest):
         assert 'Sorry, we are experiencing technical difficulties.' in response.data.decode()
 
     @mock.patch('requests.get', return_value=fake_title)
+    def test_breadcrumbs_search_results_do_not_appear(self, mock_get):
+        # This tests that when going directly to a title the search results breadcrumb doesn't show
+        response = self.app.get('/titles/DN1000')
+        page_content = response.data.decode()
+        assert 'Find a title' in page_content
+        assert 'Search results' not in page_content
+        assert 'Viewing DN1000' in page_content
+
+    @mock.patch('requests.get', return_value=fake_title)
+    def test_breadcrumbs_search_results_appear(self, mock_get):
+        response = self.app.get('/titles/DN1000?search_term="testing"')
+        page_content = response.data.decode()
+        assert 'Find a title' in page_content
+        assert 'Search results' in page_content
+        assert 'Viewing DN1000' in page_content
+
+    @mock.patch('requests.get', return_value=fake_title)
     def test_get_more_proprietor_data(self, mock_get):
         response = self.app.get('/titles/AGL1000')
         page_content = response.data.decode()


### PR DESCRIPTION
Amend server.py and search_results.html to add links back to default search page, search results page or the current page.
The search results page relies on the search term and page number being passed through the link so that the breadcrumbs can
resolve back to the correct page content and page number.
