### PR TITLE
Feature/remove page numbers in next prev links

### DIFF
--- a/service/templates/search_results.html
+++ b/service/templates/search_results.html
@@ -55,7 +55,7 @@
             </ul>
           {% endif %}
         </div>
-        <div style="text-align: center">Page {{ display_page_number }} of {{ results['number_pages'] }}</div>
+        <div id="pagination" style="text-align: center">Page {{ display_page_number }} of {{ results['number_pages'] }}</div>
       {% endif %}
     </div>
   </div>

--- a/service/templates/search_results.html
+++ b/service/templates/search_results.html
@@ -42,7 +42,6 @@
                 <li class="previous-page">
                   <a href="{{ url_for('find_titles', search_term=search_term, page=display_page_number - 1) }}">
                     <span class="pagination-label">Previous <span class="visuallyhidden">page</span></span>
-                    <span>{{ display_page_number - 1 }} of {{ results['number_pages'] }}</span>
                   </a>
                 </li>
               {% endif %}
@@ -50,13 +49,13 @@
                 <li class="next-page">
                   <a href="{{ url_for('find_titles', search_term=search_term, page=display_page_number + 1) }}">
                     <span class="pagination-label">Next <span class="visuallyhidden">page</span></span>
-                    <span>{{ display_page_number + 1 }} of {{ results['number_pages'] }}</span>
                   </a>
                 </li>
               {% endif %}
             </ul>
           {% endif %}
         </div>
+        <div style="text-align: center">Page {{ display_page_number }} of {{ results['number_pages'] }}</div>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
To be merged before https://github.com/LandRegistry/digital-register-acceptance-tests.

This covers the frontend changes for B55 where we have made the pagination less confusing for the user.
