### PR TITLE
Amend search results page so links are shown again. Code used title['…

### DIFF
--- a/service/templates/search_results.html
+++ b/service/templates/search_results.html
@@ -27,7 +27,7 @@
               {% if title['data'] %}
                 <a href="{{ url_for('get_title', title_number=title['title_number'], page=display_page_number, search_term=search_term) }}">{{ title['data']['address']['address_string'] }}</a>
               {% else %}
-                {{ title['data']['address']['address_string'] }}
+                {{ title['address'] }}
               {% endif %}
             </h2>
             <div class="font-xsmall">

--- a/service/templates/search_results.html
+++ b/service/templates/search_results.html
@@ -25,9 +25,9 @@
           <li>
             <h2 class="heading-small">
               {% if title['data'] %}
-                <a href="{{ url_for('get_title', title_number=title['title_number'], page=display_page_number, search_term=search_term) }}">{{ title['address'] }}</a>
+                <a href="{{ url_for('get_title', title_number=title['title_number'], page=display_page_number, search_term=search_term) }}">{{ title['data']['address']['address_string'] }}</a>
               {% else %}
-                {{ title['address'] }}
+                {{ title['data']['address']['address_string'] }}
               {% endif %}
             </h2>
             <div class="font-xsmall">


### PR DESCRIPTION
…address'] but should be title['data']['address']['address_string'].
