### PR TITLE
Misc fixes (Andy's work sponge)

### DIFF
--- a/service/server.py
+++ b/service/server.py
@@ -69,7 +69,7 @@ def confirm_selection(title_number, search_term):
     params['search_term'] = search_term
     params['title'] = _get_register_title(request.args.get('title', title_number))
     params['title_number'] = title_number
-    params['display_page_number'] = 1
+    params['display_page_number'] = int(request.args.get('page') or 1)
     params['MC_titleNumber'] = title_number
     # should one of: A, D, M, T, I
     params['MC_searchType'] = 'D'

--- a/service/templates/confirm_selection.html
+++ b/service/templates/confirm_selection.html
@@ -3,7 +3,7 @@
 {% block title %}Confirm your order{% endblock %}
 
 {% block header_primary %}
-  {% with title='Search results', prefix='Back to', url=url_for('find_titles_page', search_term=params['search_term'], page=params['display_page_number']), historyBased=True %}
+  {% with title='Search results', prefix='Back to', url=url_for('find_titles_page', search_term=params['search_term'], page=params['display_page_number']), historyBased=True, jsOnly=False %}
     {% include 'includes/back_link.html' %}
   {% endwith %}
 {% endblock %}

--- a/service/templates/includes/back_link.html
+++ b/service/templates/includes/back_link.html
@@ -1,4 +1,4 @@
-<a class="back-link{% if historyBased %} js-only{% endif %}" href="{{url}}"{% if historyBased %} data-back-link{% endif %}>
+<a class="back-link{% if jsOnly %} js-only{% endif %}" href="{{url}}"{% if historyBased %} data-back-link{% endif %}>
   {% if prefix %}<span class="back-link-prefix">{{prefix}}</span>{% endif %}
   <span class="back-link-destination">{{title}}</span>
 </a>

--- a/service/templates/includes/language_switcher.html
+++ b/service/templates/includes/language_switcher.html
@@ -1,5 +1,7 @@
 <div class="language-switcher {% if g.locale == 'cy' %}language-switcher-invert{% endif %}">
   <form method="get">
+    <input type="hidden" name="transid" value="{{ request.args.get('transid') }}">
+
     {% if g.locale == 'en' %}
 
       <span class="language-switcher-current">

--- a/service/templates/terms_and_conditions.html
+++ b/service/templates/terms_and_conditions.html
@@ -3,7 +3,7 @@
 {% block title %}Terms &amp; conditions{% endblock %}
 
 {% block header_primary %}
-  {% with title='Back', url='#', historyBased=True %}
+  {% with title='Back', url='#', historyBased=True, jsOnly=True %}
     {% include 'includes/back_link.html' %}
   {% endwith %}
 {% endblock %}


### PR DESCRIPTION
See https://github.com/LandRegistry/digital-register-acceptance-tests/pull/133

Includes
- Fix language switcher breaking the VAT receipt
- at the 'confirm purchase' screen, the link at the bottom of the page: 'back to search results' leads to a page not found error
