### PR TITLE
Tweaking caution title text on confirm selection page

### DIFF
--- a/service/templates/confirm_selection.html
+++ b/service/templates/confirm_selection.html
@@ -85,11 +85,16 @@
 
       </dl>
 
-      <h2 class="heading-medium collapse-top">The summary will tell you</h2>
+      {% if params['title'].get('is_caution_title') %}
+        <h2 class="heading-medium collapse-top">Land Registry does not know the owner of this property</h2>
+      {% else %}
+        <h2 class="heading-medium collapse-top">The summary will tell you</h2>
+      {% endif %}
+
       <ul class="list-bullet">
         {% if params['title'].get('is_caution_title') %}
-          <li>the name of the cautioner and their address</li>
-          <li>information about the cautioner’s claim</li>
+          <li>Someone other than the owner (known as the ‘cautioner’) has registered a right or interest in the property.</li>
+          <li><strong class="bold">The summary will give you the cautioner's name and address.</strong></li>
         {% else %}
           {% if params['title']['tenure'].upper() == 'FREEHOLD' %}
             <li>current owner's name and address</li>


### PR DESCRIPTION
Removed reference to the cautioner's claim which we do not provide
Also updated the text to more closely match v18 of the prototype which we felt was an improvement. This has gone in with the approval of the product owner, user testing pending.
